### PR TITLE
load CalendarEvents from database into _events

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -80,7 +80,7 @@ class HomeScreen extends StatelessWidget {
                         Navigator.push(
                           context,
                           MaterialPageRoute(
-                              builder: (context) => AddTodoItemScreen()),
+                              builder: (context) => AddTodoItemScreen(this.db)),
                         );
                       },
                     ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,10 +30,12 @@ dependencies:
   sqlite3_flutter_libs: ^0.2.0
   path_provider: ^1.6.27
   path: ^1.7.0
+  intl: ^0.16.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.0
+
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Load CalendarEvents in the Local DB into the `_events` variable in `calendar_screen.dart`

- Small Problem: The Calendar Events are only loaded & visible on the Calendar Screen after first returning to the main menu :(
        - i.e. After adding a new CalendarEvent to the DB it is only visible after going back to the main menu and then returning to the 
                Calendar Screen
   
I was struggling to make an async call in the `initState()` method and google didn't offer much help so I just decided to push my current implementation since we're nearing the deadline. It's working but it's just a little bit awkward as mentioned above.